### PR TITLE
Updates for Android implementation of Scopes, Collections, and SQL++

### DIFF
--- a/cblite-tests/e2e/database-test.ts
+++ b/cblite-tests/e2e/database-test.ts
@@ -35,30 +35,26 @@ export class DatabaseTests extends TestCase {
    * @returns {Promise<ITestResult>} A promise that resolves to an ITestResult object which contains the result of the verification.
    */
   async testDeleteDocument(): Promise<ITestResult> {
+    try {
     const id = '123';
-    const doc = new MutableDocument();
-    doc.setId(id);
+    const doc = new MutableDocument(id);
     doc.setString('name', 'Scott');
     await this.database?.save(doc);
-    const deleteResult = await this.database
-      .deleteDocument(doc)
-      .then(() => {
+    await this.database.deleteDocument(doc);
         return {
           testName: 'testDeleteDocument',
           success: true,
           message: 'success',
           data: undefined,
         };
-      })
-      .catch((error) => {
+    } catch(error)  {
         return {
           testName: 'testDeleteDocument',
           success: false,
           message: JSON.stringify(error),
           data: undefined 
-        };
-      });
-    return deleteResult;
+      };
+    }
   }
 
   /**

--- a/cblite-tests/e2e/replicator-test.ts
+++ b/cblite-tests/e2e/replicator-test.ts
@@ -23,7 +23,13 @@ export class ReplicatorTests extends TestCase {
    * @returns {Promise<ITestResult>} A promise that resolves to an ITestResult object which contains the result of the verification.
    */
   async testReplicatorConfigDefaultValues(): Promise<ITestResult> {
-    const target = new URLEndpoint('ws://localhost:4984/db');
+
+    //iOS and Android have different ways to connect to the emulator/simulator
+    //ios
+    //const target = new URLEndpoint('ws://localhost:4984/projects');
+    //android 
+    const target = new URLEndpoint('ws://10.0.2.2:4984/projects');
+
     const config = new ReplicatorConfiguration(target);
     config.addCollection(this.collection);
 
@@ -69,7 +75,13 @@ export class ReplicatorTests extends TestCase {
 
       //this is using the replication configuration from the Android Kotlin Learning path
       //**TODO update to use the new configuration and endpoint**
-      const target = new URLEndpoint('ws://localhost:4984/projects');
+      
+      //iOS and Android have different ways to connect to the emulator/simulator
+      //ios
+      //const target = new URLEndpoint('ws://localhost:4984/projects');
+      //android 
+      const target = new URLEndpoint('ws://10.0.2.2:4984/projects');
+
       const auth = new BasicAuthenticator('demo@example.com', 'P@ssw0rd12');
       const config = new ReplicatorConfiguration(target);
       config.addCollection(this.defaultCollection);
@@ -137,7 +149,12 @@ export class ReplicatorTests extends TestCase {
 
       //this is using the replication configuration from the Android Kotlin Learning path
       //**TODO update to use the new configuration and endpoint**
-      const target = new URLEndpoint('ws://localhost:4984/projects');
+      //iOS and Android have different ways to connect to the emulator/simulator
+      //ios
+      //const target = new URLEndpoint('ws://localhost:4984/projects');
+      //android 
+      const target = new URLEndpoint('ws://10.0.2.2:4984/projects');
+
       const auth = new BasicAuthenticator('demo@example.com', 'P@ssw0rd12');
       const config = new ReplicatorConfiguration(target);
       config.addCollection(this.defaultCollection);

--- a/cblite-tests/e2e/test-case.ts
+++ b/cblite-tests/e2e/test-case.ts
@@ -35,8 +35,8 @@ export class TestCase {
     async init(): Promise<ITestResult> {
         try {
             //try to get the platform local directory - can't run tests if we can't save a database to a directory
-            this.databaseName = `db${uuid().toString()}`;
-            //this.databaseName = `db${uuid().toString().replace(/-/g, '')}`;
+            //this.databaseName = `db${uuid().toString()}`;
+            this.databaseName = `db${uuid().toString().replace(/-/g, '')}`;
             const filePathResult = await this.getPlatformPath();
             if (filePathResult.success) {
                 this.directory = filePathResult.data;


### PR DESCRIPTION
This PR includes some small changes to fix issues found when working on getting Android working with Scopes, Collections, and SQL++:

- Fixes issues where tests were manually setting a DocumentId after creation of a MutableDoc.  Any Document (MutableDocument or Document) shouldn't allow changing of the ID as that will generate a new document in the database.

- Replication in Android is done on a different network interface than iOS.  In Android you must use the 10.0.2.2/24 network in order to talk to a Sync Gateway Server running on Localhost.  This change documented that in the test.  For now, you must manually change this based on what platform you want to run the tests on.

-Android File system has issues with using - in the file name of the database, so this change removed the dashes from the GUID we use for auto creating new databases for each test.