### PR TITLE
updated to fix issues with blobs

### DIFF
--- a/cblite/core-types.ts
+++ b/cblite/core-types.ts
@@ -536,8 +536,8 @@ export interface ICoreEngine {
      */
     collection_GetDocument(args: CollectionGetDocumentArgs): Promise<DocumentResult>;
 
-    collection_GetDocumentBlobContent(args: CollectionDocumentGetBlobContentArgs )
-        : Promise<ArrayBuffer>;
+    collection_GetBlobContent(args: CollectionDocumentGetBlobContentArgs )
+        : Promise<{data: ArrayBuffer}>;
 
     /**
      * Represents getting an Index
@@ -649,7 +649,7 @@ export interface ICoreEngine {
      * @deprecated This will be removed in future versions. Use Collection_GetDocumentBlobContent instead.
      */
     document_GetBlobContent(args: DocumentGetBlobContentArgs )
-        : Promise<ArrayBuffer>;
+        : Promise<{data: ArrayBuffer}>;
 
     /**
      * Represents getting a default path from the operating system to save a database

--- a/cblite/package.json
+++ b/cblite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cblite",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "The core Typescript API definition module for CBLite for mobile platforms",
   "main": "index.ts",
   "scripts": {

--- a/cblite/src/document.ts
+++ b/cblite/src/document.ts
@@ -40,16 +40,17 @@ export class Document {
     return this._get(key);
   }
 
-  getBlobContent(key: string, collection: Collection): Promise<ArrayBuffer> {
-    return collection
+  async getBlobContent(key: string, collection: Collection): Promise<ArrayBuffer> {
+    const data = await collection
       .getEngine()
-      .collection_GetDocumentBlobContent({
+      .collection_GetBlobContent({
         documentId: this.getId(),
         key: key,
         collectionName: collection.name,
         scopeName: collection.scope.name,
         name: collection.scope.database.getName(),
       });
+      return data.data;
   }
 
   getBoolean(key: string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "cblite-js",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Fixed an issue with the collection Get Blob Content call.  In the method mapping in Swift we had the wrong method name - it added an extra "Document" to the call.  This would result in if you called a document's getBlobContent method that it would throw an exception that the method wasn't implemented, and this was due to the naming not matching between Swift and JS.  

This also changes out the implementation because the information is actually returned in a field called data - so this will go through and properly pull the ArrayBuffer information out of data and then properly return that to the end user so they can decide how to decode it.