### PR TITLE
fix: fixed query explain returning string vs resultset

### DIFF
--- a/cblite/core-types.ts
+++ b/cblite/core-types.ts
@@ -742,7 +742,7 @@ export interface ICoreEngine {
 
   query_Execute(args: QueryExecuteArgs): Promise<Result>;
 
-  query_Explain(args: QueryExecuteArgs): Promise<Result>;
+  query_Explain(args: QueryExecuteArgs): Promise<{ data: string }>;
 
   query_RemoveChangeListener(
     args: QueryRemoveChangeListenerArgs

--- a/cblite/src/query.ts
+++ b/cblite/src/query.ts
@@ -99,7 +99,7 @@ export class Query {
    *
    * @function
    */
-  async explain(): Promise<ResultSet> {
+  async explain(): Promise<string> {
     if (this.parameters === undefined) {
       this.parameters = new Parameters();
     }
@@ -108,8 +108,7 @@ export class Query {
       query: this._queryString,
       parameters: this.parameters.get(),
     });
-    const data = queryResults.data;
-    return JSON.parse(data);
+    return queryResults.data;
   }
 
   getDatabase() {


### PR DESCRIPTION
This PR fixes an issue with Query Explain where it is returning a ResultSet but it should be only returning a single string of the explain plan.  This is a breaking fix for Ionic and will require code changes to fix it and an API change in the documentation.
