### PR TITLE
fix: crash when getting document expiration

### DIFF
--- a/cblite/src/collection.ts
+++ b/cblite/src/collection.ts
@@ -261,7 +261,7 @@ export class Collection {
       scopeName: this.scope.name,
       collectionName: this.name,
     });
-    if (date !== null && date.date !== null) {
+    if (!!date && date?.date) {
       return date.date;
     } else {
       return null;


### PR DESCRIPTION
This PR fixes a crash that would occur if you tried to get document expiration, but the expiration was not set.
The date on Android would be equal to `{}`, and `date.date` would be hit, causing an error.