### PR TITLE
fix: testDocumentChangeListenerEvent

### DIFF
--- a/cblite/src/replicated-document.ts
+++ b/cblite/src/replicated-document.ts
@@ -46,8 +46,8 @@ export function isReplicatedDocumentRepresentation(obj: any): obj is ReplicatedD
     if (object.id === null) {
       throw 'document id cannot be null';
     }
-    if (object.error !== null) {
-      if (object.error.message === null) {
+    if (object.error) {
+      if (!object.error.message) {
         throw 'document error is incomplete';
       }
     }


### PR DESCRIPTION
If there is no error the `object.error` is or can be `undefined` resulting in an error. This was happening only on Android.
Before:

<img width="906" alt="Screenshot 2025-03-27 at 13 21 04" src="https://github.com/user-attachments/assets/439b5c0a-7896-435d-956a-0e8301edb23f" />

After: 
<img width="904" alt="Screenshot 2025-03-27 at 13 26 03" src="https://github.com/user-attachments/assets/a737e917-f330-4da9-ac15-2895b83a8697" />
